### PR TITLE
Don't show default plugins in admin channel add

### DIFF
--- a/botbot/apps/bots/admin.py
+++ b/botbot/apps/bots/admin.py
@@ -13,11 +13,6 @@ from botbot.apps.plugins.models import Plugin
 
 class PluginFormset(BaseInlineFormSet):
     def __init__(self, *args, **kwargs):
-        if not kwargs['instance'].pk:
-            defaults = Plugin.objects.filter(
-                slug__in=models.Channel.DEFAULT_PLUGINS)
-
-            kwargs['initial'] = [{"plugin": obj.pk} for obj in defaults]
         super(PluginFormset, self).__init__(*args, **kwargs)
 
 
@@ -26,8 +21,6 @@ class ActivePluginInline(admin.StackedInline):
     formset = PluginFormset
 
     def get_extra(self, request, obj=None, **kwargs):
-        if obj is None:
-            return len(models.Channel.DEFAULT_PLUGINS)
         return 0
 
 


### PR DESCRIPTION
Intended as a fix for #91. When adding a new channel via the admin, the channel would contain a form for each of the default plugins, but there's no way to remove one. Upon saving, no plugins were actually being created for the channel, so you'd have to go back and edit anyway. 

With this change, no plugins are listed by default when you create a new channel via the admin. 
