### PR TITLE
Add virtualenv to the apt-get install list

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -20,7 +20,7 @@ Postgresql with hStore extension
   * Homebrew: installed by default
   * Postgres.app: installed by default
 
-* **Ubuntu**: ``apt-get install postgresql-contrib-9.1 postgresql-server-dev-9.1 python-dev``
+* **Ubuntu**: ``apt-get install postgresql-contrib-9.1 postgresql-server-dev-9.1 python-dev virtualenv``
 
 Go
 ~~


### PR DESCRIPTION
Since this isn't brought in anywhere else, it'll help save some copy paste installs.