### PR TITLE
Add newline characters between each line when viewing logs as text

### DIFF
--- a/botbot/templates/logs/logs.txt
+++ b/botbot/templates/logs/logs.txt
@@ -1,9 +1,9 @@
 {%- for line in message_list %}
 {%- if line.action -%}
 [{{ line.timestamp.strftime("%H:%M:%s") }}] * {{ line.nick }} {{ line.text }}
-{%- elif line.command == "PRIVMSG" -%}
+{% elif line.command == "PRIVMSG" -%}
 [{{ line.timestamp.strftime("%H:%M:%s") }}] {% if line.nick %}<{{ line.nick }}>{% else %}*{% endif %} {{ line.text }}
-{%- else -%}
+{% else -%}
 [{{ line.timestamp.strftime("%H:%M:%s") }}] * {{ line }}
-{%- endif -%}
+{% endif -%}
 {% endfor %}


### PR DESCRIPTION
When viewing logs as text (e.g. https://botbot.me/freenode/stripe/2016-05-22.log), no newline characters are inserted between each line. This makes it needlessly hard to parse the logs.

This PR fixes the template used for the text view to append a newline character after each line.
