### PR TITLE
Don't escape strings in text view

### DIFF
--- a/botbot/templates/logs/logs.txt
+++ b/botbot/templates/logs/logs.txt
@@ -1,3 +1,4 @@
+{%- autoescape false %}
 {%- for line in message_list %}
 {%- if line.action -%}
 [{{ line.timestamp.strftime("%H:%M:%s") }}] * {{ line.nick }} {{ line.text }}
@@ -6,4 +7,5 @@
 {% else -%}
 [{{ line.timestamp.strftime("%H:%M:%s") }}] * {{ line }}
 {% endif -%}
-{% endfor %}
+{% endfor -%}
+{% endautoescape %}


### PR DESCRIPTION
Django templates autoescape strings by default. This is unnecessary when viewing logs as text.

This PR modifies the plain text template to disable autoescaping.