### PR TITLE
Fix timestamps

### DIFF
--- a/botbot/templates/logs/logs.txt
+++ b/botbot/templates/logs/logs.txt
@@ -1,11 +1,11 @@
 {%- autoescape false %}
 {%- for line in message_list %}
 {%- if line.action -%}
-[{{ line.timestamp.strftime("%H:%M:%s") }}] * {{ line.nick }} {{ line.text }}
+[{{ line.timestamp.strftime("%H:%M:%S") }}] * {{ line.nick }} {{ line.text }}
 {% elif line.command == "PRIVMSG" -%}
-[{{ line.timestamp.strftime("%H:%M:%s") }}] {% if line.nick %}<{{ line.nick }}>{% else %}*{% endif %} {{ line.text }}
+[{{ line.timestamp.strftime("%H:%M:%S") }}] {% if line.nick %}<{{ line.nick }}>{% else %}*{% endif %} {{ line.text }}
 {% else -%}
-[{{ line.timestamp.strftime("%H:%M:%s") }}] * {{ line }}
+[{{ line.timestamp.strftime("%H:%M:%S") }}] * {{ line }}
 {% endif -%}
 {% endfor -%}
 {% endautoescape %}


### PR DESCRIPTION
When viewing logs as text, the `strftime` formatting string used `%s` instead of `%S`, which output a Unix timestamp instead of seconds, e.g.:

```
[00:05:1463875506] * timebox joined the channel
```

This PR fixes that.