### PR TITLE
travis: Set dist to precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: precise
 python:
   - "2.7"
 install:


### PR DESCRIPTION
Tests fail on trusty, so better run them on precise than not at all?